### PR TITLE
Fix dc:date output for some MODS records

### DIFF
--- a/transforms/mods_to_dc.xsl
+++ b/transforms/mods_to_dc.xsl
@@ -6,13 +6,13 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!-- 
-    localizations   2016-05 bridger
-                    Dropped srw_dc namespace references
-                    Dropped mods:modsCollection test
+	localizations   2016-05 bridger
+					Dropped srw_dc namespace references
+					Dropped mods:modsCollection test
+					Added mods:dateOther[not(@*)]
 
-
-    Version 1.8		2015-03-05 tmee@loc.gov
-    				Typo mods:provence changed to mods:province
+  Version 1.8		2015-03-05 tmee@loc.gov
+					Typo mods:provence changed to mods:province
     
 	Version 1.7 	2015-01-30 ws
 					Changed dc:creator to dc:contributor if mods:name/mods:roleTerm != creator
@@ -209,7 +209,7 @@
 		</xsl:for-each>
 	</xsl:template>
 
-	<xsl:template match="mods:dateIssued | mods:dateCreated | mods:dateCaptured">
+	<xsl:template match="mods:dateIssued | mods:dateCreated | mods:dateCaptured | mods:dateOther[not(@*)]">
 		<dc:date>
 			<xsl:choose>
 				<xsl:when test="@point = 'start'">

--- a/transforms/mods_to_dc_oai.xsl
+++ b/transforms/mods_to_dc_oai.xsl
@@ -6,13 +6,13 @@
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 	<!-- 
-    localizations   2016-05 bridger
-                    Dropped srw_dc namespace references
-                    Dropped mods:modsCollection test
+  localizations   2016-05 bridger
+          Dropped srw_dc namespace references
+          Dropped mods:modsCollection test
+					Added mods:dateOther[not(@*)]
 
-
-    Version 1.8		2015-03-05 tmee@loc.gov
-    				Typo mods:provence changed to mods:province
+  Version 1.8		2015-03-05 tmee@loc.gov
+   				Typo mods:provence changed to mods:province
     
 	Version 1.7 	2015-01-30 ws
 					Changed dc:creator to dc:contributor if mods:name/mods:roleTerm != creator

--- a/transforms/mods_to_dc_oai.xsl
+++ b/transforms/mods_to_dc_oai.xsl
@@ -209,7 +209,7 @@
 		</xsl:for-each>
 	</xsl:template>
 
-	<xsl:template match="mods:dateIssued | mods:dateCreated | mods:dateCaptured">
+	<xsl:template match="mods:dateIssued | mods:dateCreated | mods:dateCaptured | mods:dateOther[not(@*)]">
 		<dc:date>
 			<xsl:choose>
 				<xsl:when test="@point = 'start'">


### PR DESCRIPTION
This PR updates a template rule to handle the following MODS:

``` xml
<originInfo>
    <dateOther>2016-05-27</dateOther>
</originInfo>
```

This was creating a problem in the WCC collection with `dc:date` in the generated DC datastream, as well as OAI_DC. 
## Testing

To see examples for testing, please visit the [mods-to-dc-breakdown](http://github.com/CanOfBees/mods-to-dc-breakdown) repository.
