### PR TITLE
Change capitalization and spacing to match dctype values.

### DIFF
--- a/transforms/mods_to_dc.xsl
+++ b/transforms/mods_to_dc.xsl
@@ -275,25 +275,25 @@
 			<dc:type>Image</dc:type>
 		</xsl:if>
 		<xsl:if test=". = 'multimedia'">
-			<dc:type>InteractiveResource</dc:type>
+			<dc:type>Interactive Resource</dc:type>
 		</xsl:if>
 		<xsl:if test=". = 'moving image'">
-			<dc:type>MovingImage</dc:type>
+			<dc:type>Image</dc:type>
 		</xsl:if>
 		<xsl:if test=". = 'three dimensional object'">
-			<dc:type>PhysicalObject</dc:type>
+			<dc:type>Physical Object</dc:type>
 		</xsl:if>
 		<xsl:if test="starts-with(., 'sound recording')">
 			<dc:type>Sound</dc:type>
 		</xsl:if>
 		<xsl:if test=". = 'still image'">
-			<dc:type>StillImage</dc:type>
+			<dc:type>Image</dc:type>
 		</xsl:if>
 		<xsl:if test=". = 'text'">
 			<dc:type>Text</dc:type>
 		</xsl:if>
 		<xsl:if test=". = 'notated music'">
-			<dc:type>Text</dc:type>
+			<dc:type>Image</dc:type>
 		</xsl:if>
 	</xsl:template>
 

--- a/transforms/mods_to_dc_oai.xsl
+++ b/transforms/mods_to_dc_oai.xsl
@@ -261,7 +261,7 @@
 			</xsl:when>	
 			<xsl:otherwise>
 				<dc:type>
-					image
+					Image
 				</dc:type>
 			</xsl:otherwise>
 		</xsl:choose>

--- a/transforms/mods_to_dc_oai.xsl
+++ b/transforms/mods_to_dc_oai.xsl
@@ -261,7 +261,7 @@
 			</xsl:when>	
 			<xsl:otherwise>
 				<dc:type>
-					Image
+					image
 				</dc:type>
 			</xsl:otherwise>
 		</xsl:choose>
@@ -285,25 +285,25 @@
 				<dc:type>Image</dc:type>
 			</xsl:when>
 			<xsl:when test=". = 'multimedia'">
-				<dc:type>InteractiveResource</dc:type>
+				<dc:type>Interactive Resource</dc:type>
 			</xsl:when>
 			<xsl:when test=". = 'moving image'">
-				<dc:type>MovingImage</dc:type>
+				<dc:type>Image</dc:type>
 			</xsl:when>
 			<xsl:when test=". = 'three dimensional object'">
-				<dc:type>PhysicalObject</dc:type>
+				<dc:type>Physical Object</dc:type>
 			</xsl:when>
 			<xsl:when test="starts-with(., 'sound recording')">
 				<dc:type>Sound</dc:type>
 			</xsl:when>
 			<xsl:when test=". = 'still image'">
-				<dc:type>StillImage</dc:type>
+				<dc:type>Image</dc:type>
 			</xsl:when>
 			<xsl:when test=". = 'text'">
 				<dc:type>Text</dc:type>
 			</xsl:when>
 			<xsl:when test=". = 'notated music'">
-				<dc:type>Text</dc:type>
+				<dc:type>Image</dc:type>
 			</xsl:when>
 			<xsl:otherwise>
 				<dc:type>Image</dc:type>


### PR DESCRIPTION
**Jira Issue**: [DIT-1375](https://jirautk.atlassian.net/browse/DIT-1375)

## What does this Pull Request do?

This PR updates the values entered in dc:type so that they follow the DCMI Type Vocabulary - https://www.dublincore.org/specifications/dublin-core/dcmi-type-vocabulary/2003-02-12/

## What's new?

Spaces were added to separate words (e.g. "PhysicalObject" is now "Physical Object"). Capitalization was added to match the values in the vocabulary (e.g. "image" is now "Image"). Additionally, notated music has been associated with "Image" rather than "Text" since this is suggested in DCMI Types.

## How should this be tested?

I'm uncertain if this code has any dependencies. @pc37utn - please comment if there are any processes that I should be aware of. This PR only changes string values and doesn't touch the code, so I don't see it affecting much (but would like to be certain)

## Interested parties
@CanOfBees 