### PR TITLE
Remove DPN notes from dc:description.

### DIFF
--- a/transforms/mods_to_dc.xsl
+++ b/transforms/mods_to_dc.xsl
@@ -193,7 +193,7 @@
 		</xsl:if>
 	</xsl:template>
 
-	<xsl:template match="mods:abstract | mods:tableOfContents | mods:note">
+	<xsl:template match='mods:abstract | mods:tableOfContents | mods:note[not(@displayLabel="dpn")]'>
 		<dc:description>
 			<xsl:value-of select="."/>
 		</dc:description>


### PR DESCRIPTION
**Jira Issue**: [DIT-1373](https://jirautk.atlassian.net/browse/DIT-1373)

## What does this Pull Request do?

Currently our DC description values generated from our MODS include note values that do not need to display for the public. This is problematic because the browse display relies on DC child derivatives and mods:note values are indiscriminately grouped with mods:abstract values in dc:description. Updating this transform will allow us to generate DC child derivatives that do not include DPN notes, which are for internal use only.

## What's new?

MODS note values with a displayLabel of "dpn" will not be pulled into dc:description.

## How should this be tested?

Test in Islandora vagrant.
1. If not already present, create a /home/islandora directory
2. Clone the repo to your server.
- cd /home/islandora
- git clone https://github.com/utkdigitalinitiatives/islandupdate
3. Edit it to fit your local systems and requirements.
4. Run the script as root (sudo -i)

## Additional Notes

Note if you can think of any ways this change would have unexpected effects on other processes.

## Interested parties

@markpbaggett @CanOfBees 